### PR TITLE
DO-6284 Update amqp.channel Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "amqp.channel",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "A simplified way to setup an AMQP connection/channel with amqplib",
   "main": "channel.js",
   "dependencies": {
-    "amqplib": "^0.3.2",
+    "amqplib": "^0.10.3",
     "bluebird": "^2.9.24",
     "uri-js": "^4.2.2"
   },
@@ -27,7 +27,7 @@
     "coverage": "istanbul cover _mocha test --recursive -- -u exports -R spec && open coverage/lcov-report/amqp.channel/index.html"
   },
   "engines": {
-    "node": ">=0.10 <0.13 || ^1"
+    "node": ">=16"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating supported node version as well as underlying lib

```
❯ npm run test
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.

> amqp.channel@1.0.4 test
> node ./node_modules/mocha/bin/mocha test



(node:28988) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
  Channel
    with no assertions
      √ should connect to the correct RabbitMQ URL
      √ should create a Channel on the Connection
      √ should mark the Channel as blocked when it gets a blocked event
      √ should mark the Channel as unblocked when it gets a blocked event
    with valid assertions
      √ should connect to the correct RabbitMQ URL
      √ should create a Channel on the Connection
      √ should mark the Channel as blocked when it gets a blocked event
      √ should mark the Channel as unblocked when it gets a blocked event
      √ should resolve with a Rabbit MQ Channel
      √ should be able to assert Exchanges
      √ should be able to check  Exchanges
      √ should be able to bind   Exchanges
      √ should be able to unbind Exchanges
      √ should be able to delete Exchanges
      √ should be able to assert Queues
      √ should be able to check  Queues
      √ should be able to unbind Queues
```